### PR TITLE
added package.json for npm

### DIFF
--- a/Source/slick.js
+++ b/Source/slick.js
@@ -1,0 +1,10 @@
+module.exports = { Slick: (function () {
+    var Parser = require("slick/Slick.Parser").Slick,
+      Finder = require("slick/Slick.Finder").Slick;
+    
+    Object.keys(Parser).forEach(function (key) {
+      Finder[key] = Parser[key];
+    });
+    return Finder;
+  }())
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "contributors"  : ["Valerio Proietti", "Thomas Aylott", "Jan Kassens"],
   "dependencies"  : [],
   "lib"           : "Source",
-  "main"          : "./Source/Slick.Finder.js",
+  "main"          : "./Source/slick.js",
   "version"       : "1.0.0"
 }


### PR DESCRIPTION
Slick.Parser.js works in Node.JS.

Some more modifications are necessary to get Slick.Finder.js to work with jsdom / SSJS, and the browser all in one.

See my node-jquery - it's pretty much the same header / footer boilerplate.

I would like to make it such that require('slick/parser') gives just the parser rather than 
require('Slick/Slick.Parser');

Let me know if your interested in those changes as well.
