### PR TITLE
Recursive matcher #2

### DIFF
--- a/Source/Slick.Finder.js
+++ b/Source/Slick.Finder.js
@@ -558,7 +558,7 @@ local.matchNode = function(node, selector, needle){
 			return this.nativeMatchesSelector.call(node, selector.replace(/\[([^=]+)=\s*([^'"\]]+?)\s*\]/g, '[$1="$2"]'));
 		} catch(matchError) {}
 	}
-	var parsed = this.Slick.parse(selector);
+	var parsed = ((selector.Slick) ? selector : this.Slick.parse(selector));
 	if (!parsed) return true;
 	parsed = parsed.reverse();
 	for (var i = 0, expression, expressions, built, length, multiple; expression = parsed.expressions[i]; i++) {


### PR DESCRIPTION
This is a faster .match function that doesnt use .search over the document

Benchmark:

https://gist.github.com/933639

Note: My matchNode implementation uses old approach of nativeMatchSelector first and then does the recursive thing. nativeMatchSelector part may be easily removed (as shown in benchmarks)

Only these two tests fail:

 expect( context.MATCH(testNode, "[attr"+ operator +"'"+ value +"']") ).toEqual(shouldBeTrue ? true : false);
and

```
 expect( context.MATCH(testNode, document.createElement('div')) ).toEqual(false);
```

Not sure what's the deal in those two failed, can you help me figure out?
