### PR TITLE
Remove the special attributeGetter for "class" in Slick

### DIFF
--- a/SlickSpec/specs/select_exhaustive.js
+++ b/SlickSpec/specs/select_exhaustive.js
@@ -29,20 +29,25 @@ function specsSelectorExhaustiveOnTag(context, tag, ns){
 			testNodeOrphaned = null;
 		});
 		
-		var it_should_select_classes = function(CLASSES){
+		var it_should_select_classes = function(CLASSES, usingAttributeSyntax){
 			
 			var testName = 'Should select element with class "'+ CLASSES.join(' ') +'"';
 			var className = CLASSES.join(' ');
 			if (className.indexOf('\\')+1) className += ' ' + CLASSES.join(' ').replace('\\','');
-			
+			var selector = '.' + CLASSES.join('.');
+			if (usingAttributeSyntax){
+				selector = '[class*=' + CLASSES.join('][class*=') + ']';
+				testName += ' using the attribute syntax';
+			}
+						
 			it(testName + ' from the document root', function(){
 				var tmpNode;
-				tmpNode = createElement();tmpNode.setAttribute('class',className);tmpNode.setAttribute('className',className);testNode.appendChild(tmpNode);
 				tmpNode = createElement();testNode.appendChild(tmpNode);
+				tmpNode = createElement();tmpNode.setAttribute('class',className);tmpNode.setAttribute('className',className);testNode.appendChild(tmpNode);
 				tmpNode = createElement();testNode.appendChild(tmpNode);
 				
 				expect(context.SELECT || global.context.SELECT).toBeDefined();
-				var result = (context.SELECT || global.context.SELECT)(testNode.ownerDocument, '.' + CLASSES.join('.'));
+				var result = (context.SELECT || global.context.SELECT)(testNode.ownerDocument, selector);
 				expect( result.length ).toEqual( 1 );
 				expect( (typeof result[0].className == 'string') ? result[0].className : result[0].getAttribute('class') ).toMatch( CLASSES.join(' ') );
 			});
@@ -54,7 +59,7 @@ function specsSelectorExhaustiveOnTag(context, tag, ns){
 				tmpNode = createElement();testNode.appendChild(tmpNode);
 				
 				expect(context.SELECT || global.context.SELECT).toBeDefined();
-				var result = (context.SELECT || global.context.SELECT)(testNode, '.' + CLASSES.join('.'));
+				var result = (context.SELECT || global.context.SELECT)(testNode, selector);
 				expect( result.length ).toEqual( 1 );
 				expect( (typeof result[0].className == 'string') ? result[0].className : result[0].getAttribute('class') ).toMatch( CLASSES.join(' ') );
 			});
@@ -66,18 +71,22 @@ function specsSelectorExhaustiveOnTag(context, tag, ns){
 				tmpNode = createElement();testNodeOrphaned.appendChild(tmpNode);
 				
 				expect(context.SELECT || global.context.SELECT).toBeDefined();
-				var result = (context.SELECT || global.context.SELECT)(testNodeOrphaned, '.' + CLASSES.join('.'));
+				var result = (context.SELECT || global.context.SELECT)(testNodeOrphaned, selector);
 				expect( result.length ).toEqual( 1 );
 				expect( (typeof result[0].className == 'string') ? result[0].className : result[0].getAttribute('class') ).toMatch( CLASSES.join(' ') );
 			});
 			
 			// it should match this class as a second class
-			if (CLASSES.length == 1) it_should_select_classes(['foo',CLASSES[0]]);
+			if (CLASSES.length == 1) it_should_select_classes(['foo',CLASSES[0]], usingAttributeSyntax);
 		};
 		
-		it_should_select_classes(CLASSES);
+		it_should_select_classes(CLASSES, false);
 		
-		for (var i=0; i < CLASSES.length; i++) it_should_select_classes([CLASSES[i]]);
+		for (var i=0; i < CLASSES.length; i++) it_should_select_classes([CLASSES[i]], false);
+
+		it_should_select_classes(CLASSES, true);
+		
+		for (var i=0; i < CLASSES.length; i++) it_should_select_classes([CLASSES[i]], true);
 		
 	});
 	

--- a/Source/Slick.Finder.js
+++ b/Source/Slick.Finder.js
@@ -601,7 +601,7 @@ local.matchSelector = function(node, tag, id, classes, attributes, pseudos){
 
 	var i, part, cls;
 	if (classes) for (i = classes.length; i--;){
-		cls = node.getAttribute('class') || node.className;
+		cls = this.getAttribute(node, 'class');
 		if (!(cls && classes[i].regexp.test(cls))) return false;
 	}
 	if (attributes) for (i = attributes.length; i--;){
@@ -858,10 +858,6 @@ for (var p in pseudos) local['pseudo:' + p] = pseudos[p];
 // attributes methods
 
 var attributeGetters = local.attributeGetters = {
-
-	'class': function(){
-		return this.getAttribute('class') || this.className;
-	},
 
 	'for': function(){
 		return ('htmlFor' in this) ? this.htmlFor : this.getAttribute('for');


### PR DESCRIPTION
AFAIK the only reason for the special attributeGetter is because getAttribute('class') is broken in IE. However, IE will use getAttributeNode('class').nodeValue since forms are broken too. That works.

Is it safe to remove the special attributeGetter for "class"? Is there another supported environment that requires classes to be read from the className property?

It's causing problems for SVG documents and possibly other documents that override className with it's own object.
