### PR TITLE
Fixes MooTools issue #2248 -  Slick.contains(document, el); failed in IE

### DIFF
--- a/SlickSpec/bootstrap/slick.slickspec.js
+++ b/SlickSpec/bootstrap/slick.slickspec.js
@@ -16,7 +16,10 @@ var setupMethods = function(window){
 	window.PARSE = function(selector){
 		return Slick.parse(selector);
 	};
-	
+	window.CONTAINS = function(context, node){
+		return Slick.contains(context, node);
+	};
+
 	window.SELECTOR = Slick;
 };
 
@@ -48,6 +51,12 @@ var verifySetupMethods = function(window){
 			expect( window.PARSE('*').expressions.length ).toEqual(1);
 			expect( window.PARSE('*').expressions[0].length ).toEqual(1);
 		});
+
+		it('should define CONTAINS', function(){
+			expect( typeof window.CONTAINS ).toEqual('function');
+			expect( typeof window.CONTAINS(window.document, window.document.body) ).toEqual('boolean');
+		});
+
 	});
 };
 

--- a/SlickSpec/specs/html.js
+++ b/SlickSpec/specs/html.js
@@ -52,6 +52,20 @@ describe('Slick', function(){
 
 	});
 
+	describe('Contains', function(){
+
+		it('should check contains for document', function(){
+			expect(context.CONTAINS(document, document)).toEqual(true);
+		});
+		it('should check contains for document', function(){
+			expect(context.CONTAINS(document, document.documentElement)).toEqual(true);
+		});
+		it('should check contains for document', function(){
+			var el = document.createElement('div')
+			expect(context.CONTAINS(document, el)).toEqual(false);
+		});
+
+	});
 
 });
 

--- a/Source/Slick.Finder.js
+++ b/Source/Slick.Finder.js
@@ -205,8 +205,14 @@ local.setDocument = function(document){
 
 	// contains
 	// FIXME: Add specs: local.contains should be different for xml and html documents?
-	features.contains = (root && this.isNativeCode(root.contains)) ? function(context, node){
+	var nativeRootContains = root && this.isNativeCode(root.contains),
+		nativeDocumentContains = document && this.isNativeCode(document.contains);
+
+	features.contains = (nativeRootContains && nativeDocumentContains) ? function(context, node){
 		return context.contains(node);
+	} : (nativeRootContains && !nativeDocumentContains) ? function(context, node){
+		// IE8 does not have .contains on document.
+		return context === node || ((context === document) ? document.documentElement : context).contains(node);
 	} : (root && root.compareDocumentPosition) ? function(context, node){
 		return context === node || !!(context.compareDocumentPosition(node) & 16);
 	} : function(context, node){


### PR DESCRIPTION
IE8 supports document.documentElement.contains(), but not document.contains().
Without mootools this would result in a 'object does not have this contains method'.
MooTools adds document.contains, which resulted in an infinite recursion loop.

Also see the original ticket https://github.com/mootools/mootools-core/issues/2248
